### PR TITLE
Fix typo in comment and like scripts

### DIFF
--- a/comment.py
+++ b/comment.py
@@ -56,7 +56,7 @@ def do_comment_by_account(account: dict, operation: OperationInfo, driver) -> bo
 
         Terminal.green(f"Operation Completed By Account Successfully\n * Account Name {account['name']}\n * Account Username : {account['username']} \n * Post Id : {post_id}", show=True)
     except Exception as e:
-        Terminal.red(f"Failed to dowing operatin for post :\n * Post Link : {operation.media_post_link}\n * Account Name : {account['name']}\n * Account Username : {account['username']}", show=True)
+        Terminal.red(f"Failed to doing operation for post :\n * Post Link : {operation.media_post_link}\n * Account Name : {account['name']}\n * Account Username : {account['username']}", show=True)
         Terminal.red(f"Errors : {e}", show=True)
         return True
 

--- a/like.py
+++ b/like.py
@@ -78,7 +78,7 @@ def do_like_by_account(account: dict, operation: OperationInfo, driver) -> bool:
 
         Terminal.green(f"Operation Completed By Account Successfully\n * Account Name {account['name']}\n * Account Username : {account['username']} \n * Post Id : {post_id}", show=True)
     except Exception as e:
-        Terminal.red(f"Failed to dowing operatin for post :\n * Post Link : {operation.media_post_link}\n * Account Name : {account['name']}\n * Account Username : {account['username']}", show=True)
+        Terminal.red(f"Failed to doing operation for post :\n * Post Link : {operation.media_post_link}\n * Account Name : {account['name']}\n * Account Username : {account['username']}", show=True)
         Terminal.red(f"Errors : {e}", show=True)
         return False
 


### PR DESCRIPTION
## Summary
- correct typo in exception messages in `comment.py` and `like.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545110586483209f9c9a39707657a9