### PR TITLE
Fix error return in comment action

### DIFF
--- a/comment.py
+++ b/comment.py
@@ -58,7 +58,7 @@ def do_comment_by_account(account: dict, operation: OperationInfo, driver) -> bo
     except Exception as e:
         Terminal.red(f"Failed to dowing operatin for post :\n * Post Link : {operation.media_post_link}\n * Account Name : {account['name']}\n * Account Username : {account['username']}", show=True)
         Terminal.red(f"Errors : {e}", show=True)
-        return True
+        return False
 
 
 


### PR DESCRIPTION
## Summary
- ensure `do_comment_by_account` returns `False` on failure

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685454f29cc88320beb2f068cf5d3353