### PR TITLE
Add do-linklist option

### DIFF
--- a/common.py
+++ b/common.py
@@ -734,6 +734,9 @@ TRM_HELP: str = (
     "    * The script reads the path from 'path.txt' to locate the operation file.\n"
     "    * Bot will display progress in the terminal.\n"
     "    * All accounts will be rotated automatically to perform the operations.\n\n"
+    + Terminal.cyan("python main.py ") + Terminal.yellow("--do-linklist=FILE") + "\n"
+    "    * Create an operation JSON from tweet links listed in FILE.\n"
+    "    * Each line in FILE should contain a tweet URL.\n\n"
 
     + Terminal.cyan("-------------------------------") + "\n"
 )


### PR DESCRIPTION
## Summary
- add `--do-linklist` CLI option
- generate operation JSON from a list of tweet links
- update `path.txt` with the created file
- document the new flag in help text

## Testing
- `python -m py_compile main.py common.py comment.py like.py reply.py`

------
https://chatgpt.com/codex/tasks/task_e_685465006dd08320962e728c8c8585dd