### PR TITLE
Fix account typo and error handling

### DIFF
--- a/comment.py
+++ b/comment.py
@@ -58,7 +58,7 @@ def do_comment_by_account(account: dict, operation: OperationInfo, driver) -> bo
     except Exception as e:
         Terminal.red(f"Failed to doing operation for post :\n * Post Link : {operation.media_post_link}\n * Account Name : {account['name']}\n * Account Username : {account['username']}", show=True)
         Terminal.red(f"Errors : {e}", show=True)
-        return True
+        return False
 
 
 

--- a/common.py
+++ b/common.py
@@ -130,7 +130,7 @@ class XTwitterAccount:
         # Set default values
         defaults = {
             "x_followers_count": 0,
-            "x_firends_count": 0,
+            "x_friends_count": 0,
             "x_media_count": 0,
             "x_statuses_count": 0,
             "x_verified": False,
@@ -564,7 +564,7 @@ def test_and_save_account_by_info(account_info: dict) -> bool:
             if "followers_count" in legacy:
                 account_doc["x_followers_count"] = legacy["followers_count"]
             if "friends_count" in legacy:
-                account_doc["x_firends_count"] = legacy["friends_count"]
+                account_doc["x_friends_count"] = legacy["friends_count"]
             if "media_count" in legacy:
                 account_doc["x_media_count"] = legacy["media_count"]
 


### PR DESCRIPTION
## Summary
- rename `x_firends_count` to `x_friends_count`
- return `False` instead of `True` when commenting fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685468561630832097565fa7e42479fe