### PR TITLE
Fix account typo and error handling

### DIFF
--- a/comment.py
+++ b/comment.py
@@ -58,7 +58,7 @@ def do_comment_by_account(account: dict, operation: OperationInfo, driver) -> bo
     except Exception as e:
         Terminal.red(f"Failed to doing operation for post :\n * Post Link : {operation.media_post_link}\n * Account Name : {account['name']}\n * Account Username : {account['username']}", show=True)
         Terminal.red(f"Errors : {e}", show=True)
-        return True
+        return False
 
 
 
@@ -74,6 +74,9 @@ def do_comment_by_accounts(ac:XTwitterAccount, driver) -> None:
         if not os.path.isfile(operation_file_path):
             Terminal.red(f"Operation file not exists at {operation_file_path}")
             quit()
+        comments_path = os.path.join(base_dir, "comments_list.json")
+        if os.path.isfile(comments_path):
+            FileSystem.fill_comments_randomly(operation_file_path, comments_path)
         operations:list[OperationInfo] = FileSystem.get_media_posts_operations_from_file(operation_file_path)
         if not operations or not isinstance(operations , list) or len(operations) <= 0:
             Terminal.red("There is not operation in the operation file", show=True)

--- a/comments_list.json
+++ b/comments_list.json
@@ -1,0 +1,5 @@
+[
+  "Great post!",
+  "Nice shot!",
+  "Well said!"
+]

--- a/common.py
+++ b/common.py
@@ -130,7 +130,7 @@ class XTwitterAccount:
         # Set default values
         defaults = {
             "x_followers_count": 0,
-            "x_firends_count": 0,
+            "x_friends_count": 0,
             "x_media_count": 0,
             "x_statuses_count": 0,
             "x_verified": False,
@@ -421,6 +421,50 @@ class FileSystem:
 
         return operations
 
+    @staticmethod
+    def fill_comments_randomly(operation_file: str, comments_file: str, output_file: str | None = None) -> None:
+        """Populate each operation's comment_to_make field with a random comment.
+
+        Parameters
+        ----------
+        operation_file : str
+            Path to the operations JSON file.
+        comments_file : str
+            Path to the JSON file containing a list of comments.
+        output_file : str | None, optional
+            If provided, the updated operations are written to this path.
+            Otherwise ``operation_file`` is overwritten.
+        """
+
+        if not os.path.isfile(operation_file):
+            raise InvalidOperationFilePath(f"Invalid [Operation File] Path '{operation_file}' , not exists")
+        if not os.path.isfile(comments_file):
+            raise InvalidOperationFilePath(f"Invalid [Comments File] Path '{comments_file}' , not exists")
+
+        try:
+            with open(comments_file, "r", encoding="utf-8") as f:
+                comments = json.load(f)
+        except json.JSONDecodeError:
+            raise InvalidOperationFile(f"Invalid Json [Comments File] Path '{comments_file}'")
+
+        if not isinstance(comments, list) or len(comments) == 0:
+            raise InvalidOperationFile("Comments file must contain a non-empty list")
+
+        try:
+            with open(operation_file, "r", encoding="utf-8") as f:
+                operations = json.load(f)
+        except json.JSONDecodeError:
+            raise InvalidOperationFile(f"Invalid Json [Operation File] Path '{operation_file}'")
+
+        if isinstance(operations, list):
+            for op in operations:
+                if isinstance(op, dict):
+                    op["comment_to_make"] = random.choice(comments).strip()
+
+        target = output_file if output_file else operation_file
+        with open(target, "w", encoding="utf-8") as f:
+            json.dump(operations, f, indent=4)
+
 # ====================================================================================================
 # utils
 
@@ -564,7 +608,7 @@ def test_and_save_account_by_info(account_info: dict) -> bool:
             if "followers_count" in legacy:
                 account_doc["x_followers_count"] = legacy["followers_count"]
             if "friends_count" in legacy:
-                account_doc["x_firends_count"] = legacy["friends_count"]
+                account_doc["x_friends_count"] = legacy["friends_count"]
             if "media_count" in legacy:
                 account_doc["x_media_count"] = legacy["media_count"]
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     # Ensure settings exist
     GlobalSettings.get_settings()
 
-    parser = ArgumentParser(description="XTwiiter Bot V1", add_help=False)
+    parser = ArgumentParser(description="XTwitter Bot V1", add_help=False)
 
     parser.add_argument("--add-account" , action="store_true")
     parser.add_argument("--del-account")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pymongo
+import mongomock
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+pymongo.MongoClient = mongomock.MongoClient
+os.environ.setdefault("MONGO_URI", "mongodb://localhost")
+os.environ.setdefault("DATABASE_NAME", "testdb")
+os.environ.setdefault("ACCOUNTS_COLLECTION", "accounts")
+os.environ.setdefault("SETTINGS_COLLECTION", "settings")
+
+from common import Utils
+
+
+def test_extract_post_rest_id_valid():
+    link = "https://x.com/user/status/1234567890123456789/photo/1"
+    assert Utils.extract_post_rest_id_from_post_link(link) == 1234567890123456789
+
+
+def test_extract_post_rest_id_invalid():
+    link = "https://x.com/user/1234567890123456789"
+    assert Utils.extract_post_rest_id_from_post_link(link) is False


### PR DESCRIPTION
## Summary
- rename `x_firends_count` to `x_friends_count`
- return `False` instead of `True` when commenting fails
- load comments from `comments_list.json` before executing operations
- fix CLI description and add utility tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685468561630832097565fa7e42479fe